### PR TITLE
Hide Game class

### DIFF
--- a/godspeed/__main__.py
+++ b/godspeed/__main__.py
@@ -1,9 +1,8 @@
-from godspeed.game import Game
+from godspeed.game import start_game
 
 
 def main():
-    game = Game()
-    game.run()
+    start_game()
 
 
 if __name__ == "__main__":

--- a/godspeed/game.py
+++ b/godspeed/game.py
@@ -8,7 +8,7 @@ from godspeed.states.main_menu import MainMenu
 from godspeed.states.world import World
 
 
-class Game:
+class _Game:
     SCREEN_FLAGS = pygame.SCALED
     FPS_CAP = 60
 
@@ -18,9 +18,9 @@ class Game:
         self.states = itertools.cycle((World, MainMenu))
         self.state = World()
 
-        self._is_running = True
+        self.is_running = True
 
-    def _grab_events(self):
+    def grab_events(self):
         """
         Return window events
         """
@@ -41,24 +41,24 @@ class Game:
             "key_press": key_press,
         }
 
-    def _update(self) -> None:
-        event_info = self._grab_events()
+    def update(self) -> None:
+        event_info = self.grab_events()
         for event in event_info["events"]:
             if event.type == pygame.QUIT:
-                self._is_running = False
+                self.is_running = False
 
         self.state.update(event_info)
         if not self.state.alive:
             self.state = next(self.states)()
 
-    def _draw(self) -> None:
+    def draw(self) -> None:
         self.screen.fill("grey")
         self.state.draw(self.screen)
 
-    async def _run(self) -> None:
-        while self._is_running:
-            self._update()
-            self._draw()
+    async def async_run(self) -> None:
+        while self.is_running:
+            self.update()
+            self.draw()
 
             pygame.display.set_caption(
                 f"Godspeed Ninja | {self.clock.get_fps():.0f} FPS"
@@ -69,4 +69,8 @@ class Game:
             await asyncio.sleep(0)
 
     def run(self) -> None:
-        asyncio.run(self._run())
+        asyncio.run(self.async_run())
+
+
+def start_game():
+    _Game().run()


### PR DESCRIPTION
This PR is more experimental.

I find out that most of `Game` class members are private (`_`) but not all of them including some sus ones (why `clock` should be public? it really looks like an implementation detail).

Going from this investigation, I think the whole class could be in fact considered private, since nothing should interact with it as far as I know (unless you want some kind of external program to act as probe and react according to current application state).

I believe this change could simplify things: no more `_` everywhere, no more question about whether this member should be public or not.